### PR TITLE
Add 'poly_lithic visualize' to export graph visuals of the config

### DIFF
--- a/poly_lithic/src/cli.py
+++ b/poly_lithic/src/cli.py
@@ -509,6 +509,24 @@ def validate(config_file, env):
             traceback.print_exc()
         sys.exit(1)
 
+@cli.command()
+@click.argument('config_file', type=click.Path(exists=True))
+@click.option('--output', '-o', type=click.Path(), required=True, help='Image file output path')
+def visualize(config_file, output):
+    """
+    Visualize the configuration as an image file
+    """
+
+    try:
+        from poly_lithic.src.config import ConfigParser
+        parser = ConfigParser(config_file)
+        cfg = parser.parse()
+        cfg.save_routing_graph(output)
+        click.echo(click.style(f'Saved to {output}', fg='green'))
+
+    except Exception as e:
+        click.echo(click.style(f'Configuration error: {e}', fg='red'), err=True)
+        sys.exit(1)
 
 # ============================================================================
 # Legacy Support Functions

--- a/poly_lithic/src/config/config_object.py
+++ b/poly_lithic/src/config/config_object.py
@@ -89,3 +89,19 @@ class ConfigObject(pydantic.BaseModel):
         if not os.path.exists('./graphs'):
             os.makedirs('./graphs')
         plt.savefig('./graphs/{}_routing_graph.png'.format(uuid4()))
+
+    def save_routing_graph(self, path: str) -> None:
+        """Save routing graph to the specified file"""
+        plt.figure(figsize=(10, 10))
+        G = self.graph
+        # Sort based on topology
+        for i, l in enumerate(nx.topological_generations(G)):
+            for n in l:
+                G.nodes[n]['layer'] = i
+        nx.draw(
+            G,
+            with_labels=True,
+            node_size=4096, # Arbitrary; looks good enough...
+            pos=nx.multipartite_layout(G, subset_key='layer', align='horizontal', scale=-2)
+        )
+        plt.savefig(path)


### PR DESCRIPTION
I was interested in exporting my own visualizations of polylithic configs, so I added `poly_lithic visualize config.yaml -o myfile.png` to do that. Not sure if this is useful to others or worthy of it's own command though.